### PR TITLE
gpt_tblの名づけでエラーが起きたため変更

### DIFF
--- a/backend/sql/DB.sql
+++ b/backend/sql/DB.sql
@@ -12,7 +12,7 @@ CREATE TABLE gpt_tbl(
     user_id         INT                             ,
     gpt_name        VARCHAR(100)    NOT NULL        ,
     gpt_img         INT             NOT NULL        ,
-    character       VARCHAR(500)    NOT NULL        ,
+    gpt_character   VARCHAR(500)    NOT NULL        ,
     position        VARCHAR(50)     NOT NULL        ,
     search          INT             DEFAULT 0       ,
     PRIMARY KEY     (gpt_id)                        ,


### PR DESCRIPTION
characterという項目名にしていたがchar型と認識されてデータベースエラーが発生
【エラー内容】
You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'character VARCHAR(500) NOT NULL , position VARCHAR(5' at line 6

解消のためcharacter→gpt_charachterに変更